### PR TITLE
fix support for multiple entry points

### DIFF
--- a/index.js
+++ b/index.js
@@ -21,7 +21,7 @@ ${footer}`
     )
   }
 
-  const processAsset = async (bundle, publicURL, processFn) => {
+  const processAsset = async (bundle, processFn) => {
     const {name} = bundle
     const wrappingCode = await processFn({name, bundler})
 
@@ -30,7 +30,7 @@ ${footer}`
     }
 
     bundle.childBundles.forEach(function(bundle) {
-      processAsset(bundle, publicURL, processFn)
+      processAsset(bundle, processFn)
     })
   }
 
@@ -39,8 +39,7 @@ ${footer}`
       const CWD = process.cwd()
       const processFn = require(path.join(CWD, '.assetWrapper.js'))
       if (processFn && typeof processFn === 'function') {
-        const publicURL = bundle.entryAsset.options.publicURL
-        await processAsset(bundle, publicURL, processFn)
+        await processAsset(bundle, processFn)
       }
     } catch (error) {
       logger.warn(

--- a/tests/file2.js
+++ b/tests/file2.js
@@ -1,0 +1,1 @@
+console.log("xyz")

--- a/tests/index.test.js
+++ b/tests/index.test.js
@@ -56,4 +56,38 @@ describe('Asset', () => {
     },
     25000
   )
+
+  it(
+    'should work with multiple entry points',
+    async () => {
+      // Init bundler
+      const bundler = new Bundler(
+        [path.join(__dirname, './file.js'), path.join(__dirname, './file2.js')],
+        {
+          outDir: path.join(__dirname, 'dist'),
+          production: true,
+          watch: false,
+          cache: false,
+          hmr: false,
+          logLevel: 0
+        }
+      )
+      // Register plugin
+      wrapperPlugin(bundler)
+
+      // Bundle everything
+      await bundler.bundle()
+
+      //   Check asset content
+      const filename = path.join(__dirname, './dist/file.js')
+      const fileContent = (await readFile(filename)).toString()
+      const fileLines = fileContent.split('\n')
+      const firstLine = fileLines[0]
+      const lastLine = fileLines[fileLines.length - 1]
+
+      expect(firstLine).toMatch('/* parcel-plugin-wrapper - 0.1.0 */')
+      expect(lastLine).toMatch('The End')
+    },
+    25000
+  )
 })

--- a/tests/mockAssetWrapper.js
+++ b/tests/mockAssetWrapper.js
@@ -4,7 +4,7 @@ const PACKAGE = require(path.join(CWD, 'package.json'))
 
 const yourAssetProcess = ({name, bundler}) => {
   // name = app.ere76r5e76r5e76r.js
-  if (name.split('.').pop() === 'js' && bundler.options.production) {
+  if (name && name.split('.').pop() === 'js' && bundler.options.production) {
     return {
       header: `/* ${PACKAGE.name} - ${PACKAGE.version} */`,
       footer: `// The End.`


### PR DESCRIPTION
### What:
This pr allows the plugin to work with projects that have multiple entry points.

### How:
For multiple entry points `bundle.entryAsset` is `undefined` which caused the plugin to blow up.
First I changed `publicURL` to equal `bundler.options.publicURL` but noticed the value is not used anywhere so I've got rid of it altogether. 

- [x] tests