### PR TITLE
use yarn on travis-ci

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 .vscode
 coverage
+node_modules

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,8 +2,8 @@ language:
 node_js:
   - "8"
 install:
-  - npm install
+  - yarn install --pure-lockfile
   - npm install -g codecov
 script:
-  - npm run test
+  - yarn run test
   - codecov


### PR DESCRIPTION
### What:
This pr makes travis-ci use yarn instead npm to make use of `yarn.lock` file.
Also it adds `node_modules` to locations ignored by git.